### PR TITLE
Suggested fix for NPE on label object. ...

### DIFF
--- a/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
+++ b/src/main/java/gov/nasa/pds/tools/validate/rule/pds4/DataDefinitionAndContentValidationRule.java
@@ -114,7 +114,8 @@ public class DataDefinitionAndContentValidationRule extends AbstractValidationRu
           getTarget(), objectCounter, -1));
       // e.printStackTrace();
     } finally {
-      label.close();
+        if(nonNull(label))
+            label.close();
     }
   }
 


### PR DESCRIPTION
Closes NASA-PDS/validate#545 

An attempt is made to execute the `close()` method on a non-existent object. 

This is the proximate fix for the NPE but it does not address why the `Label` object does not exist. It will close the ticket but we may want to leave it open for further analysis. 